### PR TITLE
Differentiate fast-forward and force update operations.

### DIFF
--- a/vcs/gitcmd/remote_update_parser.go
+++ b/vcs/gitcmd/remote_update_parser.go
@@ -42,7 +42,7 @@ func parseRemoteUpdateLine(line string) (vcs.Change, error) {
 	case " * ":
 		change.Op = vcs.NewOp
 	case "   ":
-		change.Op = vcs.UpdatedOp
+		change.Op = vcs.FFUpdatedOp
 	case " + ":
 		const suffix = " (forced update)"
 		if !strings.HasSuffix(line, suffix) {
@@ -50,7 +50,7 @@ func parseRemoteUpdateLine(line string) (vcs.Change, error) {
 		}
 		line = line[:len(line)-len(suffix)]
 		line = strings.TrimRightFunc(line, unicode.IsSpace)
-		change.Op = vcs.UpdatedOp
+		change.Op = vcs.ForceUpdatedOp
 	case " x ":
 		change.Op = vcs.DeletedOp
 	default:

--- a/vcs/gitcmd/remote_update_parser_test.go
+++ b/vcs/gitcmd/remote_update_parser_test.go
@@ -24,7 +24,7 @@ func TestParseRemoteUpdate(t *testing.T) {
 `),
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.UpdatedOp, Branch: "master"},
+					{Op: vcs.FFUpdatedOp, Branch: "master"},
 					{Op: vcs.NewOp, Branch: "new-branch"},
 				},
 			},
@@ -37,8 +37,8 @@ func TestParseRemoteUpdate(t *testing.T) {
 `),
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.UpdatedOp, Branch: "foo-branch"},
-					{Op: vcs.UpdatedOp, Branch: "master"},
+					{Op: vcs.FFUpdatedOp, Branch: "foo-branch"},
+					{Op: vcs.FFUpdatedOp, Branch: "master"},
 				},
 			},
 		},
@@ -62,7 +62,7 @@ func TestParseRemoteUpdate(t *testing.T) {
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
 					{Op: vcs.NewOp, Branch: "another-looooooong-branch-wheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
-					{Op: vcs.UpdatedOp, Branch: "master"},
+					{Op: vcs.FFUpdatedOp, Branch: "master"},
 				},
 			},
 		},
@@ -80,9 +80,9 @@ func TestParseRemoteUpdate(t *testing.T) {
 			want: vcs.UpdateResult{
 				Changes: []vcs.Change{
 					{Op: vcs.NewOp, Branch: "gofmt-circleci"},
-					{Op: vcs.UpdatedOp, Branch: "master"},
-					{Op: vcs.UpdatedOp, Branch: "refs/pull/291/merge"},
-					{Op: vcs.UpdatedOp, Branch: "refs/pull/334/merge"},
+					{Op: vcs.FFUpdatedOp, Branch: "master"},
+					{Op: vcs.ForceUpdatedOp, Branch: "refs/pull/291/merge"},
+					{Op: vcs.ForceUpdatedOp, Branch: "refs/pull/334/merge"},
 					{Op: vcs.NewOp, Branch: "refs/pull/338/head"},
 					{Op: vcs.NewOp, Branch: "refs/pull/344/head"},
 					{Op: vcs.NewOp, Branch: "refs/pull/344/merge"},

--- a/vcs/remote.go
+++ b/vcs/remote.go
@@ -41,8 +41,11 @@ const (
 	// NewOp is a branch that was created.
 	NewOp Operation = iota
 
-	// UpdatedOp is a branch that was updated.
-	UpdatedOp
+	// FFUpdatedOp is a branch that was fast-forward updated.
+	FFUpdatedOp
+
+	// ForceUpdatedOp is a branch that was force updated.
+	ForceUpdatedOp
 
 	// DeletedOp is a branch that was deleted.
 	DeletedOp

--- a/vcs/repository_test.go
+++ b/vcs/repository_test.go
@@ -1625,7 +1625,7 @@ func TestRepository_UpdateEverything(t *testing.T) {
 			newCmds: []string{"touch newfile", "git add newfile", "GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit -m newfile --author='a <a@a.com>' --date 2006-01-02T15:04:05Z", "git tag second"},
 			wantUpdateResult: &vcs.UpdateResult{
 				Changes: []vcs.Change{
-					{Op: vcs.UpdatedOp, Branch: "origin/master"},
+					{Op: vcs.FFUpdatedOp, Branch: "origin/master"},
 					{Op: vcs.NewOp, Branch: "second"},
 				},
 			},


### PR DESCRIPTION
This implements a feature requested by @slimsag.

Note this is a PR into PR #80, not into `master`.